### PR TITLE
AppsFlyer SDK update + deprecated setApplication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ google-services.json
 \.idea/misc\.xml
 
 \.idea/vcs\.xml
+
+\.idea/

--- a/README.md
+++ b/README.md
@@ -1,46 +1,56 @@
-
-
-
-
-
 # AppsFlyer Android SDK Extension for Adobe Mobile SDK
 
 ## Table of content
 - [Installation](#installation)
+- [Extension Initialisation](#Initialisation)
 - [Event Tracking](#eventTracking)
 - [Extension Callbacks](#callbacks)
 
 
 ## <a id="installation">  Installation
-
-***Important***:
-When using the AppsFlyer Adobe Extension for Android the `Application Context` must be set using the `setApplication(Application)` API.  for example:
+Import the latest `appsflyer-adobe-sdk-extension` in your build.gradle file:
+```groovy
+dependencies {
+  ...
+  implementation 'com.appsflyer:appsflyer-adobe-sdk-extension:1.1
+}
+``` 
+If missing, add Maven Central Repository to the repositories struct:
+```groovy
+repositories {  
+    mavenCentral()  
+}
+``` 
+## <a id="Initialisation"> Extension Initialisation: 
+Register the AppsFlyer extension from your `Application` class, alongside the Adobe SDK initialisation code: 
 ```java
 @Override  
 public void onCreate() {  
-    super.onCreate();  
+  super.onCreate();  
   
   MobileCore.setApplication(this);  
+  MobileCore.setLogLevel(LoggingMode.DEBUG);  
   ...
-   try {  
-        AppsFlyerAdobeExtension.setApplication(this);  
-		AppsFlyerAdobeExtension.registerExtension();
-        ...
-    }
+  try {
+  ...
+  AppsFlyerAdobeExtension.registerExtension();
+  ...
+  }
 }
 ```
 
 
-For instructions on using AppsFlyer's Adobe Mobile SDK Extension please see: https://aep-sdks.gitbook.io/docs/getting-started/create-a-mobile-property
+For Additional instructions on using AppsFlyer's Adobe Mobile SDK Extension please see: https://aep-sdks.gitbook.io/docs/getting-started/create-a-mobile-property
 
 After adding the extension to the mobile property, Dev Key field and save the extension settings. 
 (Android) App ID is automatically set to the Android Bundle identifier.
 ![AppsFlyerAdobeSDK](https://github.com/AppsFlyerSDK/AppsFlyerAdobeExtension/blob/master/gitresources/img.png)
 
-
 For more information on adding applications to the AppsFlyer dashboard see [here](https://support.appsflyer.com/hc/en-us/articles/207377436-Adding-a-New-App-to-the-AppsFlyer-Dashboard)
 
 Information on adding the extension to your Android Studio Project is available on the Launch dashboard.
+
+***Important***: the `setApplication(Application)` API was ***deprecated*** as it is no longer required.
 
 ## <a id="eventTracking"> Event Tracking
 All events that are invoked using the `MobileCore.trackAction(String action, Map<String,String> contextData)` API are automatically tracked to the AppsFlyer Platform as in-app events; For example, calling this API:
@@ -67,7 +77,7 @@ AppsFlyerAdobeExtension.registerAppsFlyerExtensionCallbacks(new AppsFlyerExtensi
   
   @Override  
   public void onCallbackError(String errorMessage) {  
-	  Log.d("TAG", errorMessage);
+    Log.d("TAG", errorMessage);
     }  
 });
 ``` 

--- a/adobeextension/build.gradle
+++ b/adobeextension/build.gradle
@@ -21,7 +21,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.appsflyer:af-android-sdk:4.8.18@aar'
+    implementation 'com.appsflyer:af-android-sdk:4.8.19@aar'
     compileOnly 'com.adobe.marketing.mobile:userprofile:1.+'
     compileOnly 'com.adobe.marketing.mobile:sdk-core:1.+'
 

--- a/adobeextension/src/main/java/com/appsflyer/adobeextension/AppsFlyerSharedStateListener.java
+++ b/adobeextension/src/main/java/com/appsflyer/adobeextension/AppsFlyerSharedStateListener.java
@@ -1,14 +1,13 @@
 package com.appsflyer.adobeextension;
 
 import android.util.Log;
+import java.util.Map;
 
 import com.adobe.marketing.mobile.Event;
 import com.adobe.marketing.mobile.ExtensionApi;
 import com.adobe.marketing.mobile.ExtensionError;
 import com.adobe.marketing.mobile.ExtensionErrorCallback;
 import com.adobe.marketing.mobile.ExtensionListener;
-
-import java.util.Map;
 
 import static com.appsflyer.adobeextension.AppsFlyerAdobeExtension.AFEXTENSION;
 
@@ -32,17 +31,23 @@ public class AppsFlyerSharedStateListener extends ExtensionListener {
 
         if ("com.adobe.module.configuration".equals(stateOwner)) {
             Map<String, Object> configurationSharedState = getParentExtension().getApi().getSharedEventState("com.adobe.module.configuration", event, errorCallback);
-
-            if (configurationSharedState != null) {
-                String appsFlyerDevKey = configurationSharedState.get("appsFlyerDevKey").toString(); //todo validate no null
-                if (appsFlyerDevKey != null) {
-                    boolean isDebug = (boolean) configurationSharedState.get("appsFlyerIsDebug");
-                    getParentExtension().handleConfigurationEvent(appsFlyerDevKey, isDebug);
+            try {
+                if (configurationSharedState != null) {
+                    if (!configurationSharedState.isEmpty() && (configurationSharedState.get("appsFlyerDevKey") != null)) {
+                        String appsFlyerDevKey = configurationSharedState.get("appsFlyerDevKey").toString();
+                        boolean isDebug = false;
+                        if (configurationSharedState.get("appsFlyerIsDebug") != null) {
+                            isDebug = (boolean) configurationSharedState.get("appsFlyerIsDebug");
+                        }
+                        getParentExtension().handleConfigurationEvent(appsFlyerDevKey, isDebug);
+                    } else {
+                        Log.e(AFEXTENSION, "Cannot initialize AppsFlyer tracking without a valid DevKey");
+                    }
                 } else {
-                    Log.e(AFEXTENSION,"Cannot initialize AppsFlyer tracking without a valid DevKey");
+                    Log.e(AFEXTENSION, "Cannot initialize Appsflyer tracking: null configuration json");
                 }
-            } else {
-                Log.e(AFEXTENSION, "Cannot initialize Appsflyer tracking: null configuration json");
+            } catch (NullPointerException npx) {
+                Log.e(AFEXTENSION, "Exception while casting devKey to String: "+npx);
             }
         }
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,7 @@ android {
         minSdkVersion 15
         targetSdkVersion 28
         versionCode 1
-        versionName "1.0"
+        versionName "1.0.1"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
@@ -19,14 +19,11 @@ android {
 }
 
 dependencies {
-//    implementation project(':adobeextension')
-
+    implementation project(':adobeextension')
+//    implementation 'com.appsflyer:appsflyer-adobe-sdk-extension:1.0.1'
 
     implementation 'com.adobe.marketing.mobile:userprofile:1.+'
     implementation 'com.adobe.marketing.mobile:sdk-core:1.+'
-    implementation 'com.appsflyer:appsflyer-adobe-sdk-extension:1.0'
-
-
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'

--- a/app/src/main/java/com/appsflyer/adobeextensiontestapp/MainApplciation.java
+++ b/app/src/main/java/com/appsflyer/adobeextensiontestapp/MainApplciation.java
@@ -23,7 +23,7 @@ public class MainApplciation extends Application {
         MobileCore.setApplication(this);
         MobileCore.setLogLevel(LoggingMode.DEBUG);
         try {
-            AppsFlyerAdobeExtension.setApplication(this);
+//            AppsFlyerAdobeExtension.setApplication(this);
             AppsFlyerAdobeExtension.registerExtension();
             Identity.registerExtension();
             Lifecycle.registerExtension();


### PR DESCRIPTION
AppsFlyer Android SDK updated to v4.8.19
Deprecated `setApplication(Application)` as the context is obtained via reflection