### PR TITLE
Fix event checking for newer versions of adobe sdk

### DIFF
--- a/adobeextension/src/main/java/com/appsflyer/adobeextension/AppsFlyerEventListener.java
+++ b/adobeextension/src/main/java/com/appsflyer/adobeextension/AppsFlyerEventListener.java
@@ -42,7 +42,7 @@ public class AppsFlyerEventListener extends ExtensionListener {
             return;
         }
 
-        if (event.getType().equals("com.adobe.eventtype.generic.track") && event.getSource().equals("com.adobe.eventsource.requestcontent")) {
+        if (event.getType().toLowerCase().equals("com.adobe.eventtype.generic.track") && event.getSource().toLowerCase().equals("com.adobe.eventsource.requestcontent")) {
             Map<String,Object> eventData = event.getEventData();
             Object nestedData = eventData.get("contextdata");
             Object actionEventName = eventData.get(ACTION);

--- a/adobeextension/src/main/java/com/appsflyer/adobeextension/AppsFlyerEventListener.java
+++ b/adobeextension/src/main/java/com/appsflyer/adobeextension/AppsFlyerEventListener.java
@@ -42,7 +42,7 @@ public class AppsFlyerEventListener extends ExtensionListener {
             return;
         }
 
-        if (event.getType().toLowerCase().equals("com.adobe.eventtype.generic.track") && event.getSource().toLowerCase().equals("com.adobe.eventsource.requestcontent")) {
+        if (event.getType().equalsIgnoreCase("com.adobe.eventtype.generic.track") && event.getSource().equalsIgnoreCase("com.adobe.eventsource.requestcontent")) {
             Map<String,Object> eventData = event.getEventData();
             Object nestedData = eventData.get("contextdata");
             Object actionEventName = eventData.get(ACTION);


### PR DESCRIPTION
On newer versions of the adobe sdk these events come as 
_com.adobe.eventType.generic.track_ and _com.adobe.eventSource.requestContent_.
Not entering the if section, therefore not registering appsflyer events.